### PR TITLE
質問箱一覧ページにBasic認証を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 
 # Ignore RubyMine .idea/
 .idea/
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -43,4 +43,5 @@ group :test do
   gem 'selenium-webdriver'
 end
 
+gem 'dotenv-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     execjs (2.7.0)
     ffi (1.12.2)
@@ -261,6 +265,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  dotenv-rails
   font-awesome-sass (~> 5.8.1)
   html2slim
   jbuilder (~> 2.5)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
 class AdminController < ApplicationController
+  before_action :basic_auth
   layout 'admin'
+
+  private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      ActiveSupport::SecurityUtils.secure_compare(username, ENV['ADMIN_USERNAME']) && ActiveSupport::SecurityUtils.secure_compare(password, ENV['ADMIN_PASSWORD'])
+    end
+  end
 end


### PR DESCRIPTION
ref #3 

## 概要
・質問箱一覧ページにBasic認証を追加しました
・ユーザー名及び、パスワードの設定は`dotenv-rails`を使用して、.envファイル内に環境変数として設定できるように実装しました