### PR TITLE
質問箱管理画面の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,4 @@ gem 'bcrypt'
 gem 'dotenv-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'webpacker'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -285,6 +288,7 @@ DEPENDENCIES
   pg
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rubocop-minitest
   rubocop-performance
   rubocop-rails

--- a/app/controllers/admin/rooms_controller.rb
+++ b/app/controllers/admin/rooms_controller.rb
@@ -1,7 +1,25 @@
 # frozen_string_literal: true
 
 class Admin::RoomsController < AdminController
+  skip_before_action :basic_auth, only: :show
+  before_action :set_room, only: :show
+  before_action :question_box_auth, only: :show
+
   def index
     @rooms = Room.page(params[:page])
+  end
+
+  def show
+    @topics = @room.topics.page(params[:page])
+  end
+
+  private
+
+  def set_room
+    @room = Room.find(params[:id])
+  end
+
+  def question_box_auth
+    redirect_to room_path(@room), notice: '正しいパスワードを入力してください' unless @room.authenticate(params[:entered_password])
   end
 end

--- a/app/views/admin/rooms/show.html.slim
+++ b/app/views/admin/rooms/show.html.slim
@@ -1,0 +1,32 @@
+= render "/admin/page_header", title: "#{@room.name}の質問一覧"
+
+.t-admin__body
+  .t-admin__contents
+    .o-admin-content
+      .l-container.is-mxw-100pc
+        - if @topics.any?
+          .o-admin-content__row
+            = paginate @topics
+          .o-admin-content__row
+            table.a-basic-table
+              tr
+                th
+                  | 質問したい人
+                th
+                  | 質問内容
+                th
+                  | 作成日時
+              - @topics.each do |topic|
+                tr
+                  td
+                    = topic.who
+                  td
+                    = topic.name
+                  td
+                    = l topic.created_at, format: :long
+          .o-admin-content__row
+            = paginate @topics
+        - else
+          | まだ質問が登録されていません
+
+= link_to '質問箱トップページに戻る', @room

--- a/app/views/rooms/show.html.slim
+++ b/app/views/rooms/show.html.slim
@@ -40,3 +40,6 @@
     .form__nav
       = link_to 'イベント名を変更', edit_room_path(@room), class: 'form__nav-link a-text-link'
       = link_to '最初からやり直す', root_path, class: 'form__nav-link a-text-link'
+    = form_tag admin_room_path(@room), method: 'get' do
+      = text_field_tag :entered_password, nil, class: 'a-text-input'
+      = submit_tag '質問箱管理ページへ'

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module Tallk
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.i18n.default_locale = :ja
+    config.i18n.available_locales = :ja
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :rooms, only: :index
+    resources :rooms, only: %i[index show]
   end
 
   root 'top#index'


### PR DESCRIPTION
ref #11 

## 目的
質問箱作成の際に設定したパスワードを使用して、投稿された質問一覧を確認できる質問箱管理画面にアクセスできるようにする。

## 変更点
- `admin/rooms_controller.rb`にshowアクションを追加
- showアクションに固有の認証を追加
- 質問箱管理画面`admin/rooms/show.html.slim`を作成
- 質問箱トップページ`rooms/show.html.slim`に質問箱管理画面へのリンクとパスワード入力フォームを追加